### PR TITLE
Explicitly set the content-type for README.md

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
 
 [tool.setuptools.dynamic]
 version = {attr = "anastruct._version.__version__"}
-readme = {file = ["README.md"]}
+readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = {file = "requirements.txt"}
 
 [tool.setuptools.dynamic.optional-dependencies]


### PR DESCRIPTION
(unclear why build is automatically setting it as x-rst, which seems to violate https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme ?)