### PR TITLE
Update assembly.py

### DIFF
--- a/anastruct/fem/system_components/assembly.py
+++ b/anastruct/fem/system_components/assembly.py
@@ -223,8 +223,8 @@ def assemble_system_matrix(
     #
     # thus with appending numbers in the system matrix: column = row
 
-    for i in range(len(system.element_map)):
-        element = system.element_map[i + 1]
+    i, element in enumerate(system.element_map.values()):
+        # element = system.element_map[i + 1]
         element_matrix = element.stiffness_matrix
 
         # n1 and n2 are starting indexes of the rows and the columns for node 1 and node 2


### PR DESCRIPTION
When the user adds a node, the original element will be deleted. The SystemElements object cannot pass validation because a non-existing element was referenced. A key error will occur. To avoid this error, I use the enumerate() method.
This can avoid the the key error. The original code will reference the deleted key in SystemElements.element_map.