### PR TITLE
Update mpl.py

### DIFF
--- a/anastruct/fem/plotter/mpl.py
+++ b/anastruct/fem/plotter/mpl.py
@@ -871,8 +871,8 @@ class Plotter:
         self.plot_structure(
             figsize, 1, scale=scale, offset=offset, gridplot=gridplot, axes_i=axes_i
         )
-        assert self.system.element_map[1].axial_force is not None
-        con = len(self.system.element_map[1].axial_force)
+        assert list(self.system.element_map.values())[0].axial_force is not None
+        con = len(list(self.system.element_map.values())[0].axial_force)
 
         if factor is None:
             max_force = max(
@@ -982,8 +982,8 @@ class Plotter:
         self.plot_structure(
             figsize, 1, scale=scale, offset=offset, gridplot=gridplot, axes_i=axes_i
         )
-        assert self.system.element_map[1].bending_moment is not None
-        con = len(self.system.element_map[1].bending_moment)
+        assert list(self.system.element_map.values())[0].bending_moment is not None
+        con = len(list(self.system.element_map.values())[0].bending_moment)
         if factor is None:
             # maximum moment determined by comparing the node's moments and the sagging moments.
             max_moment = max(


### PR DESCRIPTION
I tested a simply supported beam and added a node in the beam. There was only one element before the node was added. I then added a point load at the new node. See my codes below. When a new node is inserted, the original element will be deleted. Two new elements will be defined accordingly. However, the original code still references the original key in the self.system.element_map[1]. But Key 1 has been deleted. A key error will occur. You can test my model here:

```

from anastruct import SystemElements
structure = SystemElements(EA=15000, EI=5000, mesh=101) # define elements
structure.add_element(location=[[0,0],[10,0]])

## define support
structure.add_support_hinged(node_id=1)
structure.add_support_hinged(node_id=2)
structure.insert_node(element_id=1, factor=0.4)

## define loads
structure.q_load(q=-5, element_id=[2,3],direction='element') structure.point_load(node_id=3, Fx=5, Fy=0)

## solve the numerical problem
structure.solve()

structure.show_bending_moment()

structure.show_axial_force()
```