### PR TITLE
Fix KeyError when solving after insert_node (non-contiguous element ids) (#308)

### DIFF
--- a/anastruct/fem/system_components/assembly.py
+++ b/anastruct/fem/system_components/assembly.py
@@ -223,8 +223,11 @@ def assemble_system_matrix(
     #
     # thus with appending numbers in the system matrix: column = row
 
-    for i in range(len(system.element_map)):
-        element = system.element_map[i + 1]
+    # Iterate over the actual elements rather than assuming the element ids are
+    # a contiguous 1..N sequence: remove_element (e.g. via insert_node) can leave
+    # gaps in element_map, and assembly is an order-independent accumulation into
+    # the system matrix indexed by node id (see #308).
+    for element in system.element_map.values():
         element_matrix = element.stiffness_matrix
 
         # n1 and n2 are starting indexes of the rows and the columns for node 1 and node 2

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -266,6 +266,51 @@ def describe_end_to_end_tests():
             assert SS_20.element_map[4].q_load == approx((1.6, 2.205258))
             assert SS_20.element_map[5].q_load == approx((2.205258, 3))
 
+    def context_insert_node_then_solve():
+        # insert_node deletes the split element and appends two new ones, leaving
+        # element_map with non-contiguous ids. The structure must still assemble
+        # and solve, giving the same result as the equivalent model built with
+        # that node defined up front (#308).
+        inserted = SystemElements(EA=15000, EI=5000, mesh=101)
+        inserted.add_element(location=[[0, 0], [10, 4]])
+        inserted.add_element(location=[[10, 4], [10, 0]])
+        inserted.add_support_hinged(node_id=1)
+        inserted.add_support_hinged(node_id=3)
+        inserted.q_load(q=5, element_id=1, direction="element")
+        inserted.point_load(node_id=2, Fx=4, Fy=0)
+        inserted.insert_node(element_id=2, factor=0.25)
+        inserted.point_load(node_id=4, Fx=8, Fy=0)
+        inserted.solve()
+
+        unsplit = SystemElements(EA=15000, EI=5000, mesh=101)
+        unsplit.add_element(location=[[0, 0], [10, 4]])
+        unsplit.add_element(location=[[10, 4], [10, 3]])
+        unsplit.add_element(location=[[10, 3], [10, 0]])
+        unsplit.add_support_hinged(node_id=1)
+        unsplit.add_support_hinged(node_id=4)
+        unsplit.q_load(q=5, element_id=1, direction="element")
+        unsplit.point_load(node_id=2, Fx=4, Fy=0)
+        unsplit.point_load(node_id=3, Fx=8, Fy=0)
+        unsplit.solve()
+
+        # the element ids are non-contiguous after the split
+        assert list(inserted.element_map.keys()) == [1, 3, 4]
+
+        def displacements_by_coordinate(system):
+            return {
+                (round(node.vertex.x, 6), round(node.vertex.y, 6)): (
+                    system.get_node_displacements(node_id)["ux"],
+                    system.get_node_displacements(node_id)["uy"],
+                )
+                for node_id, node in system.node_map.items()
+            }
+
+        inserted_disp = displacements_by_coordinate(inserted)
+        unsplit_disp = displacements_by_coordinate(unsplit)
+        assert set(inserted_disp) == set(unsplit_disp)
+        for coordinate, displacement in inserted_disp.items():
+            assert displacement == approx(unsplit_disp[coordinate])
+
     def context_find_node_id():
         # find_node_id() function using Example 8
 


### PR DESCRIPTION
## Summary

Fixes #308.

`insert_node()` splits an element by **appending two new elements and then removing the original** via `remove_element()`. This leaves `system.element_map` with non-contiguous keys — e.g. after inserting a node into element 2 of a 2-element model, the map holds `{1, 3, 4}`.

`assemble_system_matrix` iterated positionally:

```python
for i in range(len(system.element_map)):
    element = system.element_map[i + 1]
```

which assumes the ids are exactly `1..N`. With a gap, `element_map[2]` no longer exists and validation/solving raises `KeyError: 2`.

This positional assumption is **isolated to this one loop** — everywhere else in the codebase indexes `element_map` by an actual element id, and `add_element` assigns ids from a monotonic counter that is never reused.

## Fix

Iterate over the elements directly:

```python
for element in system.element_map.values():
```

Assembly is an order-independent accumulation into the global system matrix indexed by **node** id, so this is identical to the old behaviour for the contiguous case and correct when ids have gaps.

## Reproduction (raises on `master`)

```python
from anastruct import SystemElements
s = SystemElements(EA=15000, EI=5000, mesh=101)
s.add_element(location=[[0, 0], [10, 4]])
s.add_element(location=[[10, 4], [10, 0]])
s.add_support_hinged(node_id=1)
s.add_support_hinged(node_id=3)
s.q_load(q=5, element_id=1, direction='element')
s.point_load(node_id=2, Fx=4, Fy=0)
s.insert_node(element_id=2, factor=0.25)
s.point_load(node_id=4, Fx=8, Fy=0)
s.solve()   # KeyError: 2  (assembly.py)
```

## Verification

- New end-to-end test `context_insert_node_then_solve` reproduces the issue and additionally asserts the solved result is **numerically identical** to the equivalent model built with the extra node defined up front (same displacements at every shared node). It raises `KeyError: 2` on `master` and passes with this change.
- Full test suite passes (the 6 pre-existing `test_plotter` failures — `'Plotter' object has no attribute 'plot_structure'` — are unrelated to this change and fail identically on `master`).
- `black` and `mypy` clean on the changed files.

## Note

This supersedes #309 (from the issue reporter @thisisapple), which proposed the same `element_map.values()` idea but contains a syntax error (`for` keyword dropped) and no test. Credit to them for the original diagnosis.